### PR TITLE
Add error tracking system

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,13 @@ bool isHigh = gpio.readPin(1);
 | `getInterruptStatus()`             | Read and clear interrupt source         |
 | `setInterruptCallback(cb)`         | Set callback for interrupt handling     |
 | `handleInterrupt()`                | Handle INT signal & invoke callback     |
+| `getErrorFlags()`                  | Retrieve latched driver errors          |
+| `clearErrorFlags(mask)`            | Clear selected error flags              |
+
+### ❗ Error Handling
+
+Each driver method sets an error flag when it fails (e.g. on I²C NACK or when an invalid pin is passed). The flags persist until the call succeeds or `clearErrorFlags()` is used to reset them.
+
 
 ---
 

--- a/src/pcal95555_test.cpp
+++ b/src/pcal95555_test.cpp
@@ -102,13 +102,28 @@ int main() {
     PACL95555 dev(&mock, 0x20);
 
     // Test resetToDefault()
-    mock.write(0x20, PACL95555_REG::CONFIG_PORT_0, (uint8_t[]){0x00}, 1);
+    uint8_t tmp = 0x00;
+    mock.write(0x20, PACL95555_REG::CONFIG_PORT_0, &tmp, 1);
     dev.resetToDefault();
     assert(mock.getReg(PACL95555_REG::CONFIG_PORT_0) == 0xFF);
 
     // Test pin direction
     assert(dev.setPinDirection(3, GPIODir::Output));
     assert((mock.getReg(PACL95555_REG::CONFIG_PORT_0) & (1 << 3)) == 0);
+
+    // Simulate I2C write failure
+    mock.setNextWriteNack(2); // fail both attempts
+    assert(!dev.setPinDirection(1, GPIODir::Input));
+    assert(dev.getErrorFlags() & static_cast<uint16_t>(Error::I2CWriteFail));
+    // Successful call should clear the error
+    assert(dev.setPinDirection(1, GPIODir::Input));
+    assert((dev.getErrorFlags() & static_cast<uint16_t>(Error::I2CWriteFail)) == 0);
+
+    // Invalid pin test
+    assert(!dev.writePin(20, true));
+    assert(dev.getErrorFlags() & static_cast<uint16_t>(Error::InvalidPin));
+    dev.clearErrorFlags();
+    assert(dev.getErrorFlags() == 0);
 
     // ...additional tests as detailed earlier...
 


### PR DESCRIPTION
## Summary
- introduce `Error` enum for driver error flags
- track and clear errors across API calls
- expose `getErrorFlags` and `clearErrorFlags`
- update tests and README with new error handling

## Testing
- `g++ -std=c++11 src/pcal95555.cpp src/pcal95555_test.cpp -o test && ./test`