### PR TITLE
Add detailed docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@
 *.exe
 *.out
 *.app
+/build

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Hardware Agnostic PCAL95555 library - as used in the HardFOC-V1 controller
 **PACL95555** is a fully-featured, platform-independent C++ driver for the **PCAL9555A** GPIO expander by NXP Semiconductors. The PCAL9555A provides 16 general-purpose I/O pins (two 8-bit ports) accessible over I²C and supports advanced "Agile I/O" capabilities including interrupts, drive strength control, polarity inversion, input latching, and internal pull-up/pull-down resistors.
 
 This library abstracts all of that into a clear and extensible C++ API, ready to be used across a wide range of embedded platforms such as STM32, ESP32 (ESP-IDF), Arduino, and more.
+## 📚 Documentation
+
+For a full guide including installation steps, API usage, and platform-specific notes, see the [docs directory](./docs/index.md).
+
 
 ---
 

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -1,0 +1,41 @@
+# API Reference
+
+This section lists the most important methods provided by `PACL95555`. For a full definition see [`pacl95555.hpp`](../src/pacl95555.hpp).
+
+## Construction
+
+```cpp
+PACL95555(i2cBus *bus, uint8_t addr);
+```
+
+- `bus`: pointer to an object implementing the `i2cBus` interface.
+- `addr`: I²C address of the PCAL9555A device.
+
+## Basic I/O
+
+| Method | Description |
+| ------ | ----------- |
+| `setPinDirection(pin, dir)` | Set pin as input or output |
+| `readPin(pin)` | Read logic level |
+| `writePin(pin, value)` | Drive output pin |
+| `togglePin(pin)` | Toggle output state |
+
+Example:
+
+```cpp
+gpio.setPinDirection(3, PACL95555::GPIODir::Output);
+gpio.writePin(3, true);
+```
+
+## Advanced Features
+
+- **Pull Resistors**
+  - `setPullEnable(pin, bool)` to enable/disable
+  - `setPullDirection(pin, bool)` for pull-up or pull-down
+- **Drive Strength**
+  - `setDriveStrength(pin, Level0..Level3)` adjusts output current
+- **Interrupts**
+  - `setInterruptCallback(cb)` registers a handler
+  - `getInterruptStatus()` returns pending interrupt flags
+
+For further detail consult the inline comments in [`pacl95555.hpp`](../src/pacl95555.hpp).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,32 @@
+# Configuration
+
+The driver can be configured programmatically or through `Kconfig` options. This section covers both approaches.
+
+## Runtime Configuration
+
+The simplest method is to call the appropriate member functions at runtime:
+
+```cpp
+gpio.setPinDirection(0, PACL95555::GPIODir::Output);
+gpio.setPullEnable(0, true);
+gpio.setPullDirection(0, true);  // true = pull-up
+```
+
+Runtime configuration gives you full flexibility and can be changed any time after initialization.
+
+## Kconfig Integration
+
+For projects that use Kconfig (e.g. Zephyr, ESP-IDF) the library provides a set of options under the `PCAL95555` menu. Important entries include:
+
+- **PCAL95555_DEFAULT_ADDRESS** – I²C address of the expander
+- **PCAL95555_INIT_FROM_KCONFIG** – automatically apply configuration at startup
+- **Pin submenus** – specify direction, pull mode and initial level for each pin
+
+Call `initFromConfig()` during startup to apply the selected values.
+
+```cpp
+PACL95555 gpio(&i2c, CONFIG_PCAL95555_DEFAULT_ADDRESS);
+gpio.initFromConfig();
+```
+
+Adjust `Kconfig` to match your hardware setup. Refer to the [Hardware Overview](./hardware_overview.md) for pin capabilities.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,11 @@
+# Contributing
+
+We welcome contributions in the form of bug reports, feature requests and pull requests. To keep things organized please follow the steps below.
+
+1. **Fork the repository** and create a feature branch.
+2. **Write clear commit messages** describing your changes.
+3. **Update or add documentation** in the `docs/` folder when your changes modify the API or behavior.
+4. **Run `make test`** and ensure that all tests pass before opening a pull request.
+5. **Describe your changes** in the PR template so reviewers understand the motivation and implementation.
+
+For major changes, open an issue first to discuss your proposal.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,9 @@
+# Examples
+
+A set of minimal projects is provided in the [examples](../examples) directory. Each subfolder demonstrates the driver on a different platform.
+
+- **arduino/** – Sketch using the Arduino `Wire` library.
+- **esp32/** – ESP-IDF application.
+- **stm32/** – STM32 HAL example.
+
+To build an example, copy the code into your own project and adjust the I²C pins and device address for your hardware. The examples mirror the instructions in [Platform Integration](./platform_integration.md).

--- a/docs/guidelines.md
+++ b/docs/guidelines.md
@@ -1,0 +1,11 @@
+# Documentation Guidelines
+
+To keep the documentation clear and consistent, follow these rules when contributing updates:
+
+1. **Use Markdown headings** to create a logical hierarchy.
+2. **Prefer short code blocks** that highlight a specific concept.
+3. **Link to other documents** for deeper explanations rather than repeating content.
+4. **Keep line lengths under 120 characters** to improve readability in text editors.
+5. **Provide context** for example code so users know where to place it in their applications.
+
+When in doubt, mirror the style used in the existing documents. PRs that add new features should also update the relevant docs to maintain synchronization.

--- a/docs/hardware_overview.md
+++ b/docs/hardware_overview.md
@@ -1,0 +1,29 @@
+# Hardware Overview
+
+The PCAL9555A is a 16-bit I/O expander with an I²C interface. It offers two 8-bit ports that can be individually configured as inputs or outputs and supports a variety of features often required in embedded designs.
+
+## Key Features
+
+- Two 8-bit I/O ports for a total of 16 pins
+- Per-pin interrupt capability with input latching
+- Optional pull-up or pull-down resistors
+- Adjustable output drive strength
+- Selectable push-pull or open-drain outputs per port
+- Polarity inversion on input pins
+
+For the detailed register map, electrical characteristics and timing diagrams consult the official [NXP PCAL9555A Datasheet](../datasheet/PCAL9555A.pdf).
+
+## Registers
+
+Each feature is controlled through registers accessible over I²C. Some of the most commonly used registers are:
+
+| Register | Description |
+| -------- | ----------- |
+| `INPUT_PORT_0/1` | Current logic level on each pin |
+| `OUTPUT_PORT_0/1` | Output values driven on pins |
+| `CONFIG_PORT_0/1` | Direction (1=input, 0=output) |
+| `PULL_ENABLE_0/1` | Enable internal pull resistor |
+| `PULL_SELECT_0/1` | Choose pull-up or pull-down |
+| `INT_STATUS_0/1` | Latched interrupt source |
+
+Understanding the registers is helpful when troubleshooting or extending the driver. See the datasheet for a full list.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,17 @@
+# HF-PCAL95555 Documentation
+
+Welcome to the official documentation for **HF-PCAL95555**, a hardware-agnostic C++ driver for the PCAL9555A I/O expander by NXP. This documentation guides you from installation through advanced configuration so you can successfully integrate the library into a variety of platforms.
+
+## Contents
+
+1. [Installation](./installation.md)
+2. [Quick Start](./quickstart.md)
+3. [Configuration](./configuration.md)
+4. [API Reference](./api_reference.md)
+5. [Platform Integration](./platform_integration.md)
+6. [Examples](./examples.md)
+7. [Hardware Overview](./hardware_overview.md)
+8. [Documentation Guidelines](./guidelines.md)
+9. [Contributing](./contributing.md)
+
+Start with [Installation](./installation.md) to set up your environment, then follow the sections in order or jump directly to the topic you need.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,40 @@
+# Installation
+
+This section explains how to acquire the source, build the library and verify that everything works.
+
+## Prerequisites
+
+- **C++11** compatible compiler (e.g. `g++`, `clang++`)
+- `make` build tool
+
+For embedded targets, ensure your toolchain is configured to compile standard C++ code and provides access to an I²C implementation.
+
+## Cloning the Repository
+
+```bash
+git clone https://github.com/yourusername/pacl95555.git
+cd pacl95555
+```
+
+## Building the Static Library
+
+A simple `Makefile` is included:
+
+```bash
+make          # builds build/libpcal95555.a
+```
+
+The output `libpcal95555.a` can be linked into your application.
+
+## Running Unit Tests
+
+The library ships with a mock-based unit test suite. Run:
+
+```bash
+make test
+build/test    # executes the test binary
+```
+
+You should see `All tests passed.`
+
+Continue with the [Quick Start](./quickstart.md) once the build succeeds.

--- a/docs/platform_integration.md
+++ b/docs/platform_integration.md
@@ -1,0 +1,53 @@
+# Platform Integration
+
+`PACL95555` abstracts the I²C operations behind the `i2cBus` interface. To use the library on a new platform you must implement this interface.
+
+## ESP32 (ESP-IDF)
+
+```cpp
+class ESP32I2CBus : public PACL95555::i2cBus {
+    bool write(uint8_t addr, uint8_t reg, const uint8_t *data, size_t len) override {
+        return i2c_master_write_to_device(I2C_NUM_0, addr, &reg, 1, 50/portTICK_PERIOD_MS) == ESP_OK &&
+               i2c_master_write_to_device(I2C_NUM_0, addr, data, len, 50/portTICK_PERIOD_MS) == ESP_OK;
+    }
+    bool read(uint8_t addr, uint8_t reg, uint8_t *data, size_t len) override {
+        return i2c_master_write_read_device(I2C_NUM_0, addr, &reg, 1, data, len, 50/portTICK_PERIOD_MS) == ESP_OK;
+    }
+};
+```
+
+## Arduino (Wire)
+
+```cpp
+class ArduinoI2CBus : public PACL95555::i2cBus {
+    bool write(uint8_t addr, uint8_t reg, const uint8_t *data, size_t len) override {
+        Wire.beginTransmission(addr);
+        Wire.write(reg);
+        Wire.write(data, len);
+        return Wire.endTransmission() == 0;
+    }
+    bool read(uint8_t addr, uint8_t reg, uint8_t *data, size_t len) override {
+        Wire.beginTransmission(addr);
+        Wire.write(reg);
+        if (Wire.endTransmission(false) != 0) return false;
+        Wire.requestFrom(addr, len);
+        for (size_t i = 0; i < len; ++i) data[i] = Wire.read();
+        return true;
+    }
+};
+```
+
+## STM32 (HAL)
+
+```cpp
+class STM32I2CBus : public PACL95555::i2cBus {
+    bool write(uint8_t addr, uint8_t reg, const uint8_t *data, size_t len) override {
+        return HAL_I2C_Mem_Write(&hi2c1, addr<<1, reg, I2C_MEMADD_SIZE_8BIT, (uint8_t*)data, len, HAL_MAX_DELAY) == HAL_OK;
+    }
+    bool read(uint8_t addr, uint8_t reg, uint8_t *data, size_t len) override {
+        return HAL_I2C_Mem_Read(&hi2c1, addr<<1, reg, I2C_MEMADD_SIZE_8BIT, data, len, HAL_MAX_DELAY) == HAL_OK;
+    }
+};
+```
+
+Use the interface that matches your platform or adapt one of these examples.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,46 @@
+# Quick Start
+
+This tutorial demonstrates how to bring up a PCAL9555A expander using the library on any platform.
+
+1. **Include the header and create an I2C implementation**
+
+```cpp
+#include "pacl95555.hpp"
+
+class MyI2C : public PACL95555::i2cBus {
+    bool write(uint8_t addr, uint8_t reg, const uint8_t *data, size_t len) override;
+    bool read(uint8_t addr, uint8_t reg, uint8_t *data, size_t len) override;
+};
+```
+
+2. **Instantiate the driver**
+
+```cpp
+MyI2C i2c;
+PACL95555 gpio(&i2c, 0x20); // default I2C address
+```
+
+3. **Reset the expander to a known state and configure pins**
+
+```cpp
+gpio.resetToDefault(); // all pins become inputs with pull-ups
+gpio.setPinDirection(0, PACL95555::GPIODir::Output);
+```
+
+4. **Toggle outputs and read inputs**
+
+```cpp
+gpio.writePin(0, true);
+bool input = gpio.readPin(1);
+```
+
+5. **Handle interrupts (optional)**
+
+```cpp
+auto callback = [](uint16_t status) {
+    // respond to interrupts here
+};
+gpio.setInterruptCallback(callback);
+```
+
+For more advanced configuration, see the [Configuration guide](./configuration.md).


### PR DESCRIPTION
## Summary
- add dedicated `docs/` with in-depth documentation
- link to docs in README
- ignore build artifacts
