### PR TITLE
Fix format check globbing

### DIFF
--- a/.github/workflows/esp32-component-ci.yml
+++ b/.github/workflows/esp32-component-ci.yml
@@ -39,7 +39,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y clang-format
 
       - name: Format check
-        run: clang-format --dry-run --Werror "src/*.cpp" "src/*.hpp" "examples/**/*.cpp"
+        run: shopt -s globstar && clang-format --dry-run --Werror src/*.cpp src/*.hpp examples/**/*.cpp
 
       - name: ESP-IDF build
         uses: espressif/esp-idf-ci-action@v1


### PR DESCRIPTION
## Summary
- fix `clang-format` invocation by enabling globstar and removing quotes
