### PR TITLE
Move ESP32 component under example

### DIFF
--- a/.github/workflows/esp32-component-ci.yml
+++ b/.github/workflows/esp32-component-ci.yml
@@ -51,7 +51,7 @@ jobs:
             idf.py create-project ${{ env.BUILD_PATH }}
             cp examples/esp32/CMakeLists.txt ${{ env.BUILD_PATH }}/CMakeLists.txt
             # Adjust component path when building inside CI project
-            sed -i "s|../../components|../components|" ${{ env.BUILD_PATH }}/CMakeLists.txt
+            sed -i "s|components|../examples/esp32/components|" ${{ env.BUILD_PATH }}/CMakeLists.txt
             rm -rf ${{ env.BUILD_PATH }}/main
             cp -r examples/esp32/main ${{ env.BUILD_PATH }}/main
             # Copy shared example helpers

--- a/components/pcal95555/CMakeLists.txt
+++ b/components/pcal95555/CMakeLists.txt
@@ -1,1 +1,0 @@
-idf_component_register(SRCS "../../src/pcal95555.cpp" INCLUDE_DIRS "../../src")

--- a/examples/esp32/CMakeLists.txt
+++ b/examples/esp32/CMakeLists.txt
@@ -1,4 +1,4 @@
 cmake_minimum_required(VERSION 3.16)
-set(EXTRA_COMPONENT_DIRS ${CMAKE_CURRENT_LIST_DIR}/../../components)
+set(EXTRA_COMPONENT_DIRS ${CMAKE_CURRENT_LIST_DIR}/components)
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(pcal95555_example)

--- a/examples/esp32/components/pcal95555/CMakeLists.txt
+++ b/examples/esp32/components/pcal95555/CMakeLists.txt
@@ -1,0 +1,1 @@
+idf_component_register(SRCS "../../../../src/pcal95555.cpp" INCLUDE_DIRS "../../../../src")

--- a/examples/esp32/components/pcal95555/idf_component.yml
+++ b/examples/esp32/components/pcal95555/idf_component.yml
@@ -6,4 +6,4 @@ targets:
   - esp32
   - esp32c6
 include_dirs:
-  - ../../src
+  - ../../../../src


### PR DESCRIPTION
## Summary
- relocate the esp32 component directory under `examples/esp32`
- fix component paths in CMake and metadata
- update CI workflow to use the new component location

## Testing
- `make clean && make test`
- `./build/test`

------
https://chatgpt.com/codex/tasks/task_e_6850447b45c483289e916962b4407852