### PR TITLE
Readme liquid syntax error

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ public:
 
 ### 2. Create the driver and use it
 
+{% raw %}
 ```cpp
 MyI2c i2c;
 
@@ -191,6 +192,7 @@ if (gpio.HasAgileIO()) {
 gpio.WritePins({{0, true}, {1, false}, {2, true}});
 gpio.SetDirections({{0, GPIODir::Output}, {1, GPIODir::Input}});
 ```
+{% endraw %}
 
 ---
 


### PR DESCRIPTION
Wrap C++ code block in `{% raw %}` tags to fix Liquid syntax error in `README.md`.

Jekyll's Liquid templating engine misinterprets C++ initializer lists (e.g., `{{0, true}}`) as incomplete Liquid variables, leading to a syntax error. Wrapping the affected code block in `{% raw %}...{% endraw %}` prevents Liquid from processing its contents, allowing the C++ code to render correctly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that affects only how the README renders; no runtime or library behavior is modified.
> 
> **Overview**
> Fixes GitHub Pages/Jekyll rendering of the Quick Start C++ sample by wrapping the affected code block in `{% raw %}` / `{% endraw %}`, preventing Liquid from interpreting C++ initializer-list braces like `{{0, true}}` as template syntax.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 075085149a1502dfab16c48fb7c59567c2f8f2fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->